### PR TITLE
adds zet

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,10 @@ An extended `cp`
 A fast CSV command line toolkit written in Rust.
 <br>![GitHub Repo stars](https://img.shields.io/github/stars/BurntSushi/xsv?style=flat) ![GitHub last release](https://img.shields.io/github/release-date/BurntSushi/ripgrep?style=flat)
 
+**[zet](https://github.com/yarrow/zet)**
+Take the union, intersection, difference, etc of files — compare to `uniq` and `comm`.
+<br>![GitHub Repo stars](https://img.shields.io/github/stars/yarrow/zet?style=flat) ![GitHub last release](https://img.shields.io/github/release-date/yarrow/zet?style=flat)
+
 **[zoxide](https://github.com/ajeetdsouza/zoxide)**
 A smarter `cd` command.
 <br>![GitHub Repo stars](https://img.shields.io/github/stars/ajeetdsouza/zoxide?style=flat) ![GitHub last release](https://img.shields.io/github/release-date/ajeetdsouza/zoxide?style=flat)


### PR DESCRIPTION
Self-nomination.  I thought about putting `zet` into the Unix-to-Rust table as a near replacement for `uniq` and `comm`, but its 161 stars compared to the myriad stars of many others makes that seem a little brash, and `zet` doesn't yet support case-insensitive comparisons.